### PR TITLE
test(e2e): add end-to-end tests for Notion Chart Generator workflow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Notion Chart Generator E2E 測試用
+E2E_TEST_HOST=your_host_here
+E2E_TEST_NOTION_API_KEY=your_notion_api_key_here

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ backend/dist/
 .env.test.local
 .env.production.local
 
+# 測試相關
+playwright-report/
+test-results/
+
 # 日誌
 *.log
 logs/

--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@
 
 <br />
 一個採用現代前後端分離架構的 Web 應用程式，使用 NestJS + Next.js 技術棧，能夠連接 Notion 資料庫並將資料轉換為美觀的互動式圖表。支援多種圖表類型、資料聚合計算、即時分享和跨平台嵌入功能。
+<br />
+<br />
+
+![Notion Chart Generator Usage Demo](assets/images/notion-chart-generator-usage-demo.gif)
 
 ## 主要功能
 

--- a/e2e/create-first-chart-from-notion.spec.ts
+++ b/e2e/create-first-chart-from-notion.spec.ts
@@ -1,0 +1,436 @@
+import { test } from "@playwright/test";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+// Playwright 測試設定
+test.use({
+  trace: "on",
+  screenshot: "on",
+  video: {
+    mode: "on",
+    size: { width: 1920, height: 1080 },
+  },
+  permissions: ["clipboard-read", "clipboard-write"],
+});
+
+/**
+ * Notion Chart Generator E2E 測試
+ * 測試建立圖表的完整流程，包括載入資料庫、選擇屬性、設定篩選條件、生成圖表等。
+ * 確保所有步驟都能正常運作，並且能夠在分享連結中正確顯示圖表。
+ */
+test("Notion Chart Generator - 建立圖表流程", async ({ page }) => {
+  // 設定測試超時時間，這裡設定為 120 秒，確保有足夠時間
+  test.setTimeout(120000);
+
+  // 設定視窗大小
+  await page.setViewportSize({ width: 1920, height: 1080 });
+
+  // 前往 Notion Chart Generator 網站
+  await page.goto(process.env.E2E_TEST_HOST || "http://localhost:3000/");
+
+  // 注入滑鼠軌跡顯示腳本
+  await page.evaluate(() => {
+    const style = document.createElement("style");
+    style.innerHTML = `
+      .__pw-mouse-pointer {
+        pointer-events: none;
+        position: fixed;
+        z-index: 9999;
+        width: 24px;
+        height: 24px;
+        margin-left: -12px;
+        margin-top: -12px;
+        border-radius: 12px;
+        background: rgba(255,0,0,0.5);
+        box-shadow: 0 0 8px 2px rgba(255,0,0,0.3);
+        transition: left 0.05s linear, top 0.05s linear;
+      }
+    `;
+    document.head.appendChild(style);
+    const pointer = document.createElement("div");
+    pointer.className = "__pw-mouse-pointer";
+    document.body.appendChild(pointer);
+    document.addEventListener(
+      "mousemove",
+      (event) => {
+        pointer.style.left = event.clientX + "px";
+        pointer.style.top = event.clientY + "px";
+      },
+      true
+    );
+  });
+
+  // 輸入 Notion API 金鑰
+  const notionApiKeyInput = page.getByRole("textbox", {
+    name: "secret_xxx 或 ntn_xxx",
+  });
+  const notionApiKeyInputBoundingBox = await notionApiKeyInput.boundingBox();
+  if (notionApiKeyInputBoundingBox) {
+    await page.mouse.move(
+      (notionApiKeyInputBoundingBox?.x ?? 0) +
+        notionApiKeyInputBoundingBox.width / 2,
+      (notionApiKeyInputBoundingBox?.y ?? 0) +
+        notionApiKeyInputBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await notionApiKeyInput.fill(process.env.E2E_TEST_NOTION_API_KEY || "");
+  await page.waitForTimeout(750);
+
+  // 點擊「載入資料庫」按鈕
+  const loadDatabaseButton = page.getByRole("button", { name: "載入資料庫" });
+  const loadDatabaseButtonBoundingBox = await loadDatabaseButton.boundingBox();
+  if (loadDatabaseButtonBoundingBox) {
+    await page.mouse.move(
+      (loadDatabaseButtonBoundingBox?.x ?? 0) +
+        loadDatabaseButtonBoundingBox.width / 2,
+      (loadDatabaseButtonBoundingBox?.y ?? 0) +
+        loadDatabaseButtonBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await loadDatabaseButton.click();
+  await page.waitForTimeout(750);
+
+  // 等待資料庫載入完成
+  const databaseListComboBox = page.getByRole("combobox");
+  await databaseListComboBox.waitFor({ state: "visible" });
+  const databaseListComboBoxBoundingBox =
+    await databaseListComboBox.boundingBox();
+  if (databaseListComboBoxBoundingBox) {
+    await page.mouse.move(
+      (databaseListComboBoxBoundingBox?.x ?? 0) +
+        databaseListComboBoxBoundingBox.width / 2,
+      (databaseListComboBoxBoundingBox?.y ?? 0) +
+        databaseListComboBoxBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await databaseListComboBox.click();
+
+  // 選擇「合約」資料庫
+  const contractOption = page.getByRole("option", { name: "合約" });
+  const contractOptionBoundingBox = await contractOption.boundingBox();
+  if (contractOptionBoundingBox) {
+    await page.mouse.move(
+      (contractOptionBoundingBox?.x ?? 0) + contractOptionBoundingBox.width / 2,
+      (contractOptionBoundingBox?.y ?? 0) +
+        contractOptionBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await contractOption.click();
+  await page.waitForTimeout(750);
+
+  // 選擇 X 軸屬性
+  const xAxisCombobox = page
+    .getByRole("combobox")
+    .filter({ hasText: "選擇 X 軸屬性" });
+  const xAxisComboboxBoundingBox = await xAxisCombobox.boundingBox();
+  if (xAxisComboboxBoundingBox) {
+    await page.mouse.move(
+      (xAxisComboboxBoundingBox?.x ?? 0) + xAxisComboboxBoundingBox.width / 2,
+      (xAxisComboboxBoundingBox?.y ?? 0) + xAxisComboboxBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await xAxisCombobox.click();
+
+  const xAxisOption = page.getByRole("option", { name: "合約名稱 (title)" });
+  const xAxisOptionBoundingBox = await xAxisOption.boundingBox();
+  if (xAxisOptionBoundingBox) {
+    await page.mouse.move(
+      (xAxisOptionBoundingBox?.x ?? 0) + xAxisOptionBoundingBox.width / 2,
+      (xAxisOptionBoundingBox?.y ?? 0) + xAxisOptionBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await xAxisOption.click();
+  await page.waitForTimeout(750);
+
+  // 選擇 Y 軸屬性
+  const yAxisCombobox = page
+    .getByRole("combobox")
+    .filter({ hasText: "選擇 Y 軸屬性（可選）" });
+  const yAxisComboboxBoundingBox = await yAxisCombobox.boundingBox();
+  if (yAxisComboboxBoundingBox) {
+    await page.mouse.move(
+      (yAxisComboboxBoundingBox?.x ?? 0) + yAxisComboboxBoundingBox.width / 2,
+      (yAxisComboboxBoundingBox?.y ?? 0) + yAxisComboboxBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await yAxisCombobox.click();
+
+  const yAxisOption = page.getByRole("option", {
+    name: "合約金額 (含稅價) (number)",
+  });
+  const yAxisOptionBoundingBox = await yAxisOption.boundingBox();
+  if (yAxisOptionBoundingBox) {
+    await page.mouse.move(
+      (yAxisOptionBoundingBox?.x ?? 0) + yAxisOptionBoundingBox.width / 2,
+      (yAxisOptionBoundingBox?.y ?? 0) + yAxisOptionBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await yAxisOption.click();
+  await page.waitForTimeout(750);
+
+  // 點擊「設定篩選條件」按鈕
+  const filterButton = page.getByRole("button", { name: "設定篩選條件" });
+  const filterButtonBoundingBox = await filterButton.boundingBox();
+  if (filterButtonBoundingBox) {
+    await page.mouse.move(
+      (filterButtonBoundingBox?.x ?? 0) + filterButtonBoundingBox.width / 2,
+      (filterButtonBoundingBox?.y ?? 0) + filterButtonBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(750);
+  }
+  await filterButton.click();
+  await page.waitForTimeout(750);
+
+  // 選擇篩選條件
+  const filterCombobox = page
+    .getByRole("combobox")
+    .filter({ hasText: "選擇屬性" });
+  const filterComboboxBoundingBox = await filterCombobox.boundingBox();
+  if (filterComboboxBoundingBox) {
+    await page.mouse.move(
+      (filterComboboxBoundingBox?.x ?? 0) + filterComboboxBoundingBox.width / 2,
+      (filterComboboxBoundingBox?.y ?? 0) +
+        filterComboboxBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await filterCombobox.click();
+  await page.waitForTimeout(500);
+
+  const filterOption = page.getByRole("option", {
+    name: "合約處理狀態 (status)",
+  });
+  const filterOptionBoundingBox = await filterOption.boundingBox();
+  if (filterOptionBoundingBox) {
+    await page.mouse.move(
+      (filterOptionBoundingBox?.x ?? 0) + filterOptionBoundingBox.width / 2,
+      (filterOptionBoundingBox?.y ?? 0) + filterOptionBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await filterOption.click();
+  await page.waitForTimeout(500);
+
+  // 選擇篩選條件類型
+  const filterConditionCombobox = page
+    .getByRole("combobox")
+    .filter({ hasText: "選擇條件" });
+  const filterConditionComboboxBoundingBox =
+    await filterConditionCombobox.boundingBox();
+  if (filterConditionComboboxBoundingBox) {
+    await page.mouse.move(
+      (filterConditionComboboxBoundingBox?.x ?? 0) +
+        filterConditionComboboxBoundingBox.width / 2,
+      (filterConditionComboboxBoundingBox?.y ?? 0) +
+        filterConditionComboboxBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await filterConditionCombobox.click();
+  await page.waitForTimeout(500);
+
+  const conditionOption = page.getByRole("option", {
+    name: "等於",
+    exact: true,
+  });
+  const conditionOptionBoundingBox = await conditionOption.boundingBox();
+  if (conditionOptionBoundingBox) {
+    await page.mouse.move(
+      (conditionOptionBoundingBox?.x ?? 0) +
+        conditionOptionBoundingBox.width / 2,
+      (conditionOptionBoundingBox?.y ?? 0) +
+        conditionOptionBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await conditionOption.click();
+  await page.waitForTimeout(500);
+
+  // 選擇篩選值
+  const filterValueCombobox = page
+    .getByRole("combobox")
+    .filter({ hasText: "選擇選項" });
+  const filterValueComboboxBoundingBox =
+    await filterValueCombobox.boundingBox();
+  if (filterValueComboboxBoundingBox) {
+    await page.mouse.move(
+      (filterValueComboboxBoundingBox?.x ?? 0) +
+        filterValueComboboxBoundingBox.width / 2,
+      (filterValueComboboxBoundingBox?.y ?? 0) +
+        filterValueComboboxBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await filterValueCombobox.click();
+  await page.waitForTimeout(500);
+
+  const filterValueOption = page
+    .getByRole("option")
+    .filter({ hasText: "未開始" });
+  const filterValueOptionBoundingBox = await filterValueOption.boundingBox();
+  if (filterValueOptionBoundingBox) {
+    await page.mouse.move(
+      (filterValueOptionBoundingBox?.x ?? 0) +
+        filterValueOptionBoundingBox.width / 2,
+      (filterValueOptionBoundingBox?.y ?? 0) +
+        filterValueOptionBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await filterValueOption.click();
+  await page.waitForTimeout(500);
+
+  // 點擊「套用篩選」按鈕
+  const applyFilterButton = page.getByRole("button", { name: /^套用篩選.*/ });
+  const applyFilterButtonBoundingBox = await applyFilterButton.boundingBox();
+  if (applyFilterButtonBoundingBox) {
+    await page.mouse.move(
+      (applyFilterButtonBoundingBox?.x ?? 0) +
+        applyFilterButtonBoundingBox.width / 2,
+      (applyFilterButtonBoundingBox?.y ?? 0) +
+        applyFilterButtonBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await applyFilterButton.click();
+  await page.waitForTimeout(500);
+
+  // 點擊「生成圖表」按鈕
+  const generateChartButton = page.getByRole("button", { name: "生成圖表" });
+  const generateChartButtonBoundingBox =
+    await generateChartButton.boundingBox();
+  if (generateChartButtonBoundingBox) {
+    await page.mouse.move(
+      (generateChartButtonBoundingBox?.x ?? 0) +
+        generateChartButtonBoundingBox.width / 2,
+      (generateChartButtonBoundingBox?.y ?? 0) +
+        generateChartButtonBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await generateChartButton.click();
+  await page.locator("canvas").waitFor({ state: "visible" });
+  await page.waitForTimeout(1250);
+
+  // 重新選擇圖表類型
+  const radarChartButton = page.getByRole("button", { name: "雷達圖" });
+  const radarChartButtonBoundingBox = await radarChartButton.boundingBox();
+  if (radarChartButtonBoundingBox) {
+    await page.mouse.move(
+      (radarChartButtonBoundingBox?.x ?? 0) +
+        radarChartButtonBoundingBox.width / 2,
+      (radarChartButtonBoundingBox?.y ?? 0) +
+        radarChartButtonBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await radarChartButton.click();
+  await page.waitForTimeout(750);
+
+  // 點擊「資料」按鈕
+  const dataButton = page.getByRole("button", { name: "Data" });
+  await dataButton.waitFor({ state: "visible" });
+  const dataButtonBoundingBox = await dataButton.boundingBox();
+  if (dataButtonBoundingBox) {
+    await page.mouse.move(
+      (dataButtonBoundingBox?.x ?? 0) + dataButtonBoundingBox.width / 2,
+      (dataButtonBoundingBox?.y ?? 0) + dataButtonBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await dataButton.click();
+  await page.waitForTimeout(500);
+
+  const heading = await page.getByRole("heading", { name: "資料表格" });
+  await heading.waitFor({ state: "visible" });
+  const headingBoundingBox = await heading.boundingBox();
+  if (headingBoundingBox) {
+    await page.mouse.move(
+      (headingBoundingBox?.x ?? 0) + headingBoundingBox.width / 2,
+      (headingBoundingBox?.y ?? 0) + headingBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await page.waitForTimeout(750);
+
+  // 點擊「分享」按鈕
+  const shareButton = await page.getByRole("button", { name: "分享" });
+  await shareButton.waitFor({ state: "visible" });
+  const shareButtonBoundingBox = await shareButton.boundingBox();
+  if (shareButtonBoundingBox) {
+    await page.mouse.move(
+      (shareButtonBoundingBox?.x ?? 0) + shareButtonBoundingBox.width / 2,
+      (shareButtonBoundingBox?.y ?? 0) + shareButtonBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await shareButton.click();
+
+  // 等待分享對話框出現
+  const shareDialog = await page.getByRole("dialog", { name: "分享圖表" });
+  shareDialog.waitFor({ state: "visible" });
+  await page.waitForTimeout(250);
+
+  // 點擊「分享連結」按鈕
+  const shareLinkButton = page
+    .locator("div")
+    .filter({
+      hasText:
+        /^分享連結 \(動態快照\)此連結可在新分頁或視窗中開啟，以嵌入模式顯示圖表$/,
+    })
+    .getByRole("button");
+  const shareLinkButtonBoundingBox = await shareLinkButton.boundingBox();
+  if (shareLinkButtonBoundingBox) {
+    await page.mouse.move(
+      (shareLinkButtonBoundingBox?.x ?? 0) +
+        shareLinkButtonBoundingBox.width / 2,
+      (shareLinkButtonBoundingBox?.y ?? 0) +
+        shareLinkButtonBoundingBox.height / 2,
+      { steps: 20 }
+    );
+    await page.waitForTimeout(250);
+  }
+  await shareLinkButton.click();
+  await page.waitForTimeout(750);
+
+  // 從剪貼簿中讀取分享連結並導航到該連結
+  const clipboardContent = await page.evaluate(() =>
+    navigator.clipboard.readText()
+  );
+  await page.goto(clipboardContent);
+
+  // 等待分享連結的圖表畫布出現
+  const shareLinkChartCanvas = await page.locator("canvas");
+  await shareLinkChartCanvas.waitFor({ state: "visible" });
+  await page.waitForTimeout(1250);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,19 @@
 {
   "name": "notion-chart-generator",
-  "version": "1.0.0",
+  "version": "1.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "notion-chart-generator",
-      "version": "1.0.0",
+      "version": "1.1.3",
       "license": "MIT",
+      "dependencies": {
+        "@playwright/test": "^1.54.2",
+        "dotenv": "^17.2.1"
+      },
       "devDependencies": {
+        "@types/node": "^24.1.0",
         "concurrently": "^8.2.2",
         "rimraf": "^6.0.1"
       }
@@ -147,6 +152,31 @@
       },
       "funding": {
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.54.2.tgz",
+      "integrity": "sha512-A+znathYxPf+72riFd1r1ovOLqsIIB0jKIoPjyK2kqEIe30/6jF6BC7QNluHuwUmsD2tv1XZVugN8GqfTMOxsA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "24.1.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.1.0.tgz",
+      "integrity": "sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.8.0"
       }
     },
     "node_modules/ansi-regex": {
@@ -300,6 +330,18 @@
         "url": "https://opencollective.com/date-fns"
       }
     },
+    "node_modules/dotenv": {
+      "version": "17.2.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.1.tgz",
+      "integrity": "sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -339,6 +381,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -493,6 +549,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/require-directory": {
@@ -680,6 +766,13 @@
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
       "license": "0BSD"
+    },
+    "node_modules/undici-types": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
+      "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,12 @@
   "author": "Steve CY Lin",
   "license": "MIT",
   "devDependencies": {
+    "@types/node": "^24.1.0",
     "concurrently": "^8.2.2",
     "rimraf": "^6.0.1"
+  },
+  "dependencies": {
+    "@playwright/test": "^1.54.2",
+    "dotenv": "^17.2.1"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: "./e2e",
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: "html",
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: "on-first-retry",
+  },
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});


### PR DESCRIPTION
This pull request introduces end-to-end (E2E) testing capabilities for the Notion Chart Generator project and includes updates to documentation and dependencies. The most significant changes involve adding Playwright configuration for E2E testing, updating dependencies, and enhancing the README with a usage demo.

### E2E Testing Setup:
* Added a Playwright configuration file (`playwright.config.ts`) to define E2E testing settings, including parallel test execution, retry logic, and browser-specific configurations.
* Introduced environment variables in `.env.example` for E2E testing, such as `E2E_TEST_HOST` and `E2E_TEST_NOTION_API_KEY`.

### Dependency Updates:
* Updated `package.json` to include new dependencies: `@playwright/test` for E2E testing and `dotenv` for managing environment variables. Also added `@types/node` to `devDependencies`.

### Documentation Enhancements:
* Enhanced the `README.md` with a GIF demo showcasing the usage of the Notion Chart Generator.