### PR TITLE
fix: Update changelog and version to 1.1.6; enhance property extraction support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,28 @@
 # Changelog
 
+## [1.1.6] - 2025-08-09
+
+### Fixed
+
+- **[聚合計算] Notion 屬性聚合未依選項產生正確結果** ([#21](https://github.com/SteveLin100132/notion-chart-generator/issues/21))
+
+  - 修正 `extractPropertyValue` 函數缺少多種 Notion 屬性類型處理的問題
+  - 新增 `status` 屬性支援：正確提取狀態名稱（如 "進行中"、"已完成"、"待處理"）
+  - 新增 `people` 屬性支援：正確提取人員名稱並以逗號分隔
+  - 新增 `created_by`/`last_edited_by` 屬性支援：正確提取創建者/編輯者名稱
+  - 新增其他屬性類型支援：
+    - `relation` - 關聯屬性：顯示關聯數量
+    - `files` - 檔案屬性：顯示檔案數量
+    - `unique_id` - 唯一 ID 屬性：提取數字或前綴
+    - `created_time`/`last_edited_time` - 時間屬性：提取時間戳
+  - 同步修復前端（`frontend/src/lib/api.ts`）和後端（`backend/src/snapshot/snapshot.service.ts`）
+  - 解決 Issue #21：Status 屬性聚合現在會根據不同狀態選項正確分組統計，不再顯示空白欄位名稱
+
 ## [1.1.5] - 2025-08-03
 
 ### Fixed
 
-- **切換資料庫時自動清空進階篩選條件**
+- **切換資料庫時自動清空進階篩選條件** ([#15](https://github.com/SteveLin100132/notion-chart-generator/issues/15))
 
   - 修正圖表設定頁面，當使用者重新選擇資料庫時，進階篩選（Query Builder 內的條件）會自動清空，避免舊資料庫的篩選條件殘留導致圖表生成錯誤。
   - 完全符合預期行為，提升使用體驗。

--- a/backend/src/snapshot/snapshot.service.ts
+++ b/backend/src/snapshot/snapshot.service.ts
@@ -461,8 +461,29 @@ export class SnapshotService {
         return (
           property.multi_select?.map((item: any) => item.name).join(', ') || ''
         );
+      case 'status':
+        return property.status?.name || '';
+      case 'people':
+        return property.people?.map((p: any) => p.name).join(', ') || '';
+      case 'created_by':
+        return property.created_by?.name || '';
+      case 'last_edited_by':
+        return property.last_edited_by?.name || '';
+      case 'relation':
+        return `${property.relation?.length || 0} 個關聯`;
+      case 'files':
+        return `${property.files?.length || 0} 個檔案`;
+      case 'unique_id':
+        return (
+          property.unique_id?.number?.toString() ||
+          property.unique_id?.prefix ||
+          ''
+        );
       case 'date':
         return property.date?.start || '';
+      case 'created_time':
+      case 'last_edited_time':
+        return property[property.type] || '';
       case 'checkbox':
         return property.checkbox;
       case 'url':

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -226,8 +226,29 @@ export const dataProcessor = {
         return (
           property.multi_select?.map((item: any) => item.name).join(", ") || ""
         );
+      case "status":
+        return property.status?.name || "";
+      case "people":
+        return property.people?.map((p: any) => p.name).join(", ") || "";
+      case "created_by":
+        return property.created_by?.name || "";
+      case "last_edited_by":
+        return property.last_edited_by?.name || "";
+      case "relation":
+        return `${property.relation?.length || 0} 個關聯`;
+      case "files":
+        return `${property.files?.length || 0} 個檔案`;
+      case "unique_id":
+        return (
+          property.unique_id?.number?.toString() ||
+          property.unique_id?.prefix ||
+          ""
+        );
       case "date":
         return property.date?.start || "";
+      case "created_time":
+      case "last_edited_time":
+        return property[property.type] || "";
       case "checkbox":
         return property.checkbox;
       case "url":

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "notion-chart-generator",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Notion Chart Generator - 現代化的資料視覺化工具",
   "main": "index.js",
   "directories": {


### PR DESCRIPTION
Fixes: #21

This pull request focuses on improving the accuracy and completeness of Notion property aggregation, especially for the "Status" property, and adds support for multiple additional Notion property types in both the frontend and backend. It also updates the package version and documents the changes in the changelog.

**Notion property extraction and aggregation improvements:**

* Added support for extracting and aggregating several Notion property types in both `extractPropertyValue` (backend) and the frontend data processor, including:
  - [`status`](diffhunk://#diff-451fb05e4d9ec5b4ed74778787eec4b99df2cd7d31c86521d5c287b21c5468c5R464-R486): Correctly extracts and groups by status name (e.g., "進行中", "已完成", "待處理") [[1]](diffhunk://#diff-451fb05e4d9ec5b4ed74778787eec4b99df2cd7d31c86521d5c287b21c5468c5R464-R486) [[2]](diffhunk://#diff-fc0647beab64e4906eb6a581b0476dba8073601854e616d8ca3345539b0412b8R229-R251)
  - [`people`](diffhunk://#diff-451fb05e4d9ec5b4ed74778787eec4b99df2cd7d31c86521d5c287b21c5468c5R464-R486): Extracts and joins people names [[1]](diffhunk://#diff-451fb05e4d9ec5b4ed74778787eec4b99df2cd7d31c86521d5c287b21c5468c5R464-R486) [[2]](diffhunk://#diff-fc0647beab64e4906eb6a581b0476dba8073601854e616d8ca3345539b0412b8R229-R251)
  - `created_by`/`last_edited_by`: Extracts creator/editor names [[1]](diffhunk://#diff-451fb05e4d9ec5b4ed74778787eec4b99df2cd7d31c86521d5c287b21c5468c5R464-R486) [[2]](diffhunk://#diff-fc0647beab64e4906eb6a581b0476dba8073601854e616d8ca3345539b0412b8R229-R251)
  - [`relation`](diffhunk://#diff-451fb05e4d9ec5b4ed74778787eec4b99df2cd7d31c86521d5c287b21c5468c5R464-R486): Shows relation count [[1]](diffhunk://#diff-451fb05e4d9ec5b4ed74778787eec4b99df2cd7d31c86521d5c287b21c5468c5R464-R486) [[2]](diffhunk://#diff-fc0647beab64e4906eb6a581b0476dba8073601854e616d8ca3345539b0412b8R229-R251)
  - [`files`](diffhunk://#diff-451fb05e4d9ec5b4ed74778787eec4b99df2cd7d31c86521d5c287b21c5468c5R464-R486): Shows file count [[1]](diffhunk://#diff-451fb05e4d9ec5b4ed74778787eec4b99df2cd7d31c86521d5c287b21c5468c5R464-R486) [[2]](diffhunk://#diff-fc0647beab64e4906eb6a581b0476dba8073601854e616d8ca3345539b0412b8R229-R251)
  - [`unique_id`](diffhunk://#diff-451fb05e4d9ec5b4ed74778787eec4b99df2cd7d31c86521d5c287b21c5468c5R464-R486): Extracts number or prefix [[1]](diffhunk://#diff-451fb05e4d9ec5b4ed74778787eec4b99df2cd7d31c86521d5c287b21c5468c5R464-R486) [[2]](diffhunk://#diff-fc0647beab64e4906eb6a581b0476dba8073601854e616d8ca3345539b0412b8R229-R251)
  - `created_time`/`last_edited_time`: Extracts timestamp [[1]](diffhunk://#diff-451fb05e4d9ec5b4ed74778787eec4b99df2cd7d31c86521d5c287b21c5468c5R464-R486) [[2]](diffhunk://#diff-fc0647beab64e4906eb6a581b0476dba8073601854e616d8ca3345539b0412b8R229-R251)

* Fixed an issue where status property aggregation did not group by status options correctly, resolving Issue #21.

**Documentation and versioning:**

* Updated `CHANGELOG.md` to document the new property type support and the status aggregation fix.
* Bumped the package version to `1.1.6` in `package.json`.