### PR TITLE
chore: Implement CI/CD workflows for GitHub Pages deployment and update master.yml for pull request handling

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,65 @@
+name: Deploy Website to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master # 當推送到 master 分支時觸發
+    paths:
+      - "website/**" # 只有當 website 目錄有變更時才觸發
+  workflow_dispatch: # 允許手動觸發
+
+# 設定 GITHUB_TOKEN 的權限
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# 確保同時只有一個部署任務在執行
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18"
+          cache: "npm"
+          cache-dependency-path: "website/package-lock.json"
+
+      - name: Install dependencies
+        run: |
+          cd website
+          npm i
+
+      - name: Build website
+        run: |
+          cd website
+          npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./website/dist"
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,7 +1,8 @@
 name: CI - master
 
 on:
-  push:
+  pull_request:
+    types: [closed]
     branches:
       - "master"
 
@@ -54,6 +55,7 @@ jobs:
   bump-version:
     name: Bump Version and Update GitHub Variable
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'build')
     outputs:
       new_version: ${{ steps.bump.outputs.new_version }}
     # needs: unit-test # 等 unit-test 成功才執行
@@ -87,6 +89,7 @@ jobs:
   build-image:
     name: Build and Push Docker Image
     runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'build')
     needs:
       # - unit-test # 等 unit-test 成功才執行
       - bump-version # 等 bump-version 成功才執行

--- a/website/index.html
+++ b/website/index.html
@@ -1,10 +1,10 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="./logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Notion Chart Generator</title>
   </head>
   <body>
     <div id="root"></div>

--- a/website/public/logo.svg
+++ b/website/public/logo.svg
@@ -1,0 +1,6 @@
+<svg width="60" height="60" viewBox="0 0 60 60" fill="none" xmlns="http://www.w3.org/2000/svg">
+<rect x="1.5" y="1.5" width="57" height="57" rx="8.5" stroke="black" stroke-width="3"/>
+<rect x="13" y="10" width="7" height="40" rx="3" fill="black"/>
+<rect x="27" y="18" width="7" height="32" rx="3" fill="black"/>
+<rect x="41" y="26" width="7" height="24" rx="3" fill="black"/>
+</svg>


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for deploying the website to GitHub Pages and refines the existing CI/CD workflow to trigger on merged pull requests to the master branch. It also updates the website's HTML metadata and favicon. The most important changes are grouped below:

**CI/CD Workflow Improvements:**

* Added a new `.github/workflows/deploy-website.yml` workflow to automate deployment of the `website` directory to GitHub Pages, including build steps and artifact uploading.
* Modified `.github/workflows/master.yml` to trigger only when a pull request is closed and merged into the master branch, instead of on every push.
* Added conditions to the `bump-version` and `build-image` jobs in `.github/workflows/master.yml` to ensure they only run when the merged pull request has the `build` label. [[1]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842R58) [[2]](diffhunk://#diff-38ee08b0d1916cb5b9d8a093e986366eaafd908bc1f516f4fced0033c155d842R92)

**Website Metadata Update:**

* Updated `website/index.html` to use a new favicon (`logo.svg`) and changed the page title to "Notion Chart Generator" for improved branding.