### PR TITLE
fix(Navbar): correct logo image path from absolute to relative

### DIFF
--- a/website/src/components/Navbar.tsx
+++ b/website/src/components/Navbar.tsx
@@ -21,7 +21,7 @@ const Navbar: React.FC = () => {
             }}
           >
             <img
-              src="/logo.png"
+              src="./logo.png"
               alt="logo"
               className="w-7 h-7 object-contain"
             />


### PR DESCRIPTION
This pull request makes a small update to the `Navbar` component to fix the path to the logo image.

* Changed the logo image source in the `Navbar` component from `/logo.png` to `./logo.png` to ensure the image loads correctly in different deployment environments. (`website/src/components/Navbar.tsx`)