### PR TITLE
fix(HowToUseSection): update wireframe image paths to use relative paths

### DIFF
--- a/website/src/components/HowToUseSection.tsx
+++ b/website/src/components/HowToUseSection.tsx
@@ -7,9 +7,9 @@ const HowToUseSection: React.FC = () => {
   // 對應每個 tab 的 wireframe 圖片
   const wireframeImages = React.useMemo(
     () => [
-      "/images/basic-feature-demo.gif",
-      "/images/advanced-filter-demo.gif",
-      "/images/share-embed-demo.gif",
+      "./images/basic-feature-demo.gif",
+      "./images/advanced-filter-demo.gif",
+      "./images/share-embed-demo.gif",
     ],
     []
   );


### PR DESCRIPTION
This pull request makes a minor update to the image paths in the `HowToUseSection` component to use relative paths instead of absolute ones. This change helps ensure the images are referenced correctly in different deployment environments.

* Changed image paths in the `wireframeImages` array from absolute (`/images/...`) to relative (`./images/...`) in `website/src/components/HowToUseSection.tsx`.