### PR TITLE
fix(workflow): change trigger branch from master to deploy-doks for DOKS deployment

### DIFF
--- a/.github/workflows/deploy-doks.yaml
+++ b/.github/workflows/deploy-doks.yaml
@@ -3,7 +3,7 @@ name: Deploy to DOKS
 on:
   push:
     branches:
-      - master
+      - deploy-doks
 
 env:
   GITHUB_ACTOR: ${{ github.actor }}


### PR DESCRIPTION
This pull request makes a small update to the deployment workflow configuration. The deployment workflow will now trigger on pushes to the `deploy-doks` branch instead of the `master` branch.