### PR TITLE
chore(k8s): update commonName and dnsNames in certificate and ingress configurations for clarity

### DIFF
--- a/k8s/certificate.yaml
+++ b/k8s/certificate.yaml
@@ -8,6 +8,6 @@ spec:
   issuerRef:
     name: letsencrypt-prod
     kind: ClusterIssuer
-  commonName: 188-166-204-94.nip.io
+  commonName: notion-chart-generator.188-166-204-94.nip.io
   dnsNames:
-    - 188-166-204-94.nip.io
+    - notion-chart-generator.188-166-204-94.nip.io

--- a/k8s/ingress.yaml
+++ b/k8s/ingress.yaml
@@ -8,10 +8,10 @@ spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - 188-166-204-94.nip.io
+        - notion-chart-generator.188-166-204-94.nip.io
       secretName: notion-chart-generator-tls
   rules:
-    - host: 188-166-204-94.nip.io
+    - host: notion-chart-generator.188-166-204-94.nip.io
       http:
         paths:
           - path: /api


### PR DESCRIPTION
This pull request updates the domain configuration for the Notion Chart Generator service in the Kubernetes manifests. The changes ensure that the service uses the more specific subdomain `notion-chart-generator.188-166-204-94.nip.io` instead of the previous generic domain.

Domain configuration updates:

* Updated the `commonName` and `dnsNames` fields in `k8s/certificate.yaml` to use `notion-chart-generator.188-166-204-94.nip.io` for certificate issuance.
* Updated the `hosts` and `rules` fields in `k8s/ingress.yaml` to route traffic for `notion-chart-generator.188-166-204-94.nip.io` and use the corresponding TLS secret.